### PR TITLE
extend forecast to 40 hours, improve backtest saving functionality

### DIFF
--- a/gradboost_pv/models/training.py
+++ b/gradboost_pv/models/training.py
@@ -173,37 +173,42 @@ def run_experiment(
         # print(f"Median test MAE: {np.round(test_mae, 5)}")
         maes.append(test_mae)
 
-    if save_errors_locally:
-        errors_test = pd.DataFrame(
-            data=np.concatenate(
-                [
-                    y_test.values,
-                    y_pred_test_50.reshape(-1, 1),
-                    y_pred_test_10.reshape(-1, 1),
-                    y_pred_test_90.reshape(-1, 1),
-                    (y_test.values - y_pred_test_50.reshape(-1, 1)) ** 2,
-                    np.abs(y_test.values - y_pred_test_50.reshape(-1, 1)),
-                ],
-                axis=1,
-            ),
-            columns=["y", "pred", "p10", "p90", "test_mse", "test_mae"],
-            index=y_test.index,
-        )
-        errors_train = pd.DataFrame(
-            data=np.concatenate(
-                [
-                    (y_train.values - y_pred_train.reshape(-1, 1)) ** 2,
-                    np.abs(y_train.values - y_pred_train.reshape(-1, 1)),
-                ],
-                axis=1,
-            ),
-            columns=["train_mse", "train_mae"],
-            index=y_train.index,
-        )
+        if save_errors_locally:
+            errors_test = pd.DataFrame(
+                data=np.concatenate(
+                    [
+                        y_test.values,
+                        y_pred_test_50.reshape(-1, 1),
+                        y_pred_test_10.reshape(-1, 1),
+                        y_pred_test_90.reshape(-1, 1),
+                        (y_test.values - y_pred_test_50.reshape(-1, 1)) ** 2,
+                        np.abs(y_test.values - y_pred_test_50.reshape(-1, 1)),
+                    ],
+                    axis=1,
+                ),
+                columns=["y", "pred", "p10", "p90", "test_mse", "test_mae"],
+                index=y_test.index,
+            )
+            errors_train = pd.DataFrame(
+                data=np.concatenate(
+                    [
+                        (y_train.values - y_pred_train.reshape(-1, 1)) ** 2,
+                        np.abs(y_train.values - y_pred_train.reshape(-1, 1)),
+                    ],
+                    axis=1,
+                ),
+                columns=["train_mse", "train_mae"],
+                index=y_train.index,
+            )
 
-        errors = pd.concat([errors_train, errors_test], axis=1)
-        errors.to_csv(errors_local_save_file)
+            errors = pd.concat([errors_train, errors_test], axis=1)
 
+            errors_local_save_file_year = f"{errors_local_save_file}_year_{year}.csv"
+
+            print(errors_local_save_file_year) 
+
+            errors.to_csv(errors_local_save_file_year)
+            
     return ExperimentSummary(
         train_pinballs[1],
         test_pinballs[1],

--- a/gradboost_pv/models/training.py
+++ b/gradboost_pv/models/training.py
@@ -205,10 +205,10 @@ def run_experiment(
 
             errors_local_save_file_year = f"{errors_local_save_file}_year_{year}.csv"
 
-            print(errors_local_save_file_year) 
+            print(errors_local_save_file_year)
 
             errors.to_csv(errors_local_save_file_year)
-            
+
     return ExperimentSummary(
         train_pinballs[1],
         test_pinballs[1],

--- a/scripts/models/train/region_filtered_model.py
+++ b/scripts/models/train/region_filtered_model.py
@@ -91,7 +91,12 @@ def main(path_to_processed_nwp: Path, nwp_variables: list[str]) -> Dict[Hour, Ex
             processed_nwp, gsp_data, np.timedelta64(forecast_horizon_hour, "h")
         )
         training_results = run_experiment(
-            X, y, DEFFAULT_HYPARAM_CONFIG, forecast_hour=forecast_horizon_hour, save_errors_locally=True, errors_local_save_file=f"results/backtest_test_horizon_{forecast_horizon_hour}"
+            X,
+            y,
+            DEFFAULT_HYPARAM_CONFIG,
+            forecast_hour=forecast_horizon_hour,
+            save_errors_locally=True,
+            errors_local_save_file=f"results/backtest_test_horizon_{forecast_horizon_hour}",
         )
 
         results[forecast_horizon_hour] = training_results

--- a/scripts/models/train/region_filtered_model.py
+++ b/scripts/models/train/region_filtered_model.py
@@ -78,7 +78,7 @@ def main(path_to_processed_nwp: Path, nwp_variables: list[str]) -> Dict[Hour, Ex
 
     results = dict()
 
-    for forecast_horizon_hour in range(37):
+    for forecast_horizon_hour in range(41):
         print(forecast_horizon_hour)
         # independently fit an XGBoost model for each forecast horizon
         processed_nwp = load_all_variable_slices(
@@ -91,7 +91,7 @@ def main(path_to_processed_nwp: Path, nwp_variables: list[str]) -> Dict[Hour, Ex
             processed_nwp, gsp_data, np.timedelta64(forecast_horizon_hour, "h")
         )
         training_results = run_experiment(
-            X, y, DEFFAULT_HYPARAM_CONFIG, forecast_hour=forecast_horizon_hour
+            X, y, DEFFAULT_HYPARAM_CONFIG, forecast_hour=forecast_horizon_hour, save_errors_locally=True, errors_local_save_file=f"results/backtest_test_horizon_{forecast_horizon_hour}"
         )
 
         results[forecast_horizon_hour] = training_results


### PR DESCRIPTION
Small change to way in which the code saves the forecast. Updated values so forecast can generate predictions for a 40 hour horizon. 