### PR TITLE
Read model bucket path from ML_MODEL_BUCKET env var

### DIFF
--- a/gradboost_pv/models/s3.py
+++ b/gradboost_pv/models/s3.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 env = os.environ.get("ENVIRONMENT", "development")
-BUCKET_NAME = f"nowcasting-national-forecaster-models-{env}"
+BUCKET_NAME = os.environ.get("ML_MODEL_BUCKET", f"uk-national-forecaster-models-{env}")
 MODEL = "v4"
 
 


### PR DESCRIPTION
Currently the model bucket is hardcoded instead of reading from the application environment. This small PR addresses this problem.